### PR TITLE
Introduce and satisfy Eastwood

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -38,4 +38,10 @@
            ;; build a jar, https://juxt.pro/blog/posts/pack-maven.html
            :pack {:extra-deps {pack/pack.alpha {:git/url "https://github.com/juxt/pack.alpha.git"
                                                 :sha "2769a6224bfb938e777906ea311b3daf7d2220f5"}}
-                  :main-opts ["-m"]}}}
+                  :main-opts ["-m"]}
+
+           ;; clojure -M:dev-figwheel:fig-repl:dev-shadow:test:eastwood
+           :eastwood
+           {:main-opts ["-m" "eastwood.lint" {:config-files ["eastwood.clj"]}]
+            :extra-deps {org.clojure/tools.nrepl {:mvn/version "0.2.13"}
+                         jonase/eastwood {:mvn/version "0.9.9"}}}}}

--- a/eastwood.clj
+++ b/eastwood.clj
@@ -1,0 +1,6 @@
+;; avoid a corner case in Eastwood / tools.analyzer:
+(require 'figwheel.main.api)
+
+(disable-warning
+ {:linter :constant-test
+  :if-inside-macroexpansion-of #{'suitable.complete-for-nrepl/with-cljs-env}})

--- a/src/dev/suitable/scratch.clj
+++ b/src/dev/suitable/scratch.clj
@@ -1,4 +1,4 @@
-(ns dev.suitable.scratch
+(ns suitable.scratch
   (:require [clojure.zip :as zip]
             [clojure.spec.alpha :as s]
             [clojure.spec.test.alpha :as st]))

--- a/src/main/suitable/complete_for_nrepl.clj
+++ b/src/main/suitable/complete_for_nrepl.clj
@@ -110,7 +110,7 @@
   `cider.piggieback/generate-delegating-repl-env`."
   [renv]
   (= (some-> 'cljs.repl.node.NodeEnv
-             resolve
+             ^Class (resolve)
              .getName
              (string/replace "." "_"))
      (-> renv

--- a/src/main/suitable/js_completions.cljc
+++ b/src/main/suitable/js_completions.cljc
@@ -25,8 +25,9 @@
        (cljs-eval-fn ns code))
      (catch #?(:clj Exception :cljs js/Error) e {:error e}))))
 
-(defn find-prefix [form]
+(defn find-prefix
   "Tree search for the symbol '__prefix. Returns a zipper."
+  [form]
   (loop [node (tree-zipper form)]
     (if (= '__prefix__ (zip/node node))
       node
@@ -131,7 +132,6 @@
           ;; or "(this-as this this)" for symbol = "js/window"
           obj-expr (cl-format nil "(this-as this ~[this~:;(.. this ~{-~A~^ ~})~])"
                               (count obj-expr-parts) obj-expr-parts)]
-      obj-expr-parts
       {:prefix prefix
        :prepend-to-candidate (str "js/" dotted-obj-expr)
        :vars-have-dashes? false

--- a/src/main/suitable/utils.clj
+++ b/src/main/suitable/utils.clj
@@ -1,5 +1,7 @@
 (ns suitable.utils
-  (:require cljs.env ))
+  (:require
+   [cljs.env]
+   [cljs.repl]))
 
 (defn wrapped-cljs-repl-eval
   "cljs-eval-fn for `suitable.cljs-completions` that can be used when a

--- a/src/test/suitable/complete_for_nrepl_test.clj
+++ b/src/test/suitable/complete_for_nrepl_test.clj
@@ -9,8 +9,8 @@
 (def ^:dynamic *handler* cider-nrepl-handler)
 (def ^:dynamic *session* nil)
 
-(def ^:dynamic *server* nil)
-(def ^:dynamic *transport* nil)
+(def ^:dynamic ^nrepl.server.Server *server* nil)
+(def ^:dynamic ^nrepl.transport.FnTransport *transport* nil)
 
 (defn message
   ([msg] (message msg true))
@@ -20,14 +20,20 @@
        (nrepl/combine-responses responses)
        responses))))
 
+(def handler nil)
+(def server nil)
+(def transport nil)
+(def client nil)
+(def session nil)
+
 (defmacro start [renv-form]
   `(do
-     (def handler (default-handler #'piggieback/wrap-cljs-repl #'wrap-complete-standalone))
-     (def server    (start-server :handler handler))
-     (def transport (nrepl/connect :port (:port server)))
-     (def client  (nrepl/client transport 3000))
-     (def session (nrepl/client-session client))
-     (alter-var-root #'*server*    (constantly server))
+     (alter-var-root #'handler (constantly (default-handler #'piggieback/wrap-cljs-repl #'wrap-complete-standalone)))
+     (alter-var-root #'server (constantly (start-server :handler handler)))
+     (alter-var-root #'transport (constantly (nrepl/connect :port (:port server))))
+     (alter-var-root #'client (constantly (nrepl/client transport 3000)))
+     (alter-var-root #'session (constantly (nrepl/client-session client)))
+     (alter-var-root #'*server* (constantly server))
      (alter-var-root #'*transport* (constantly transport))
      (alter-var-root #'*session* (constantly session))
      (dorun (message

--- a/src/test/suitable/js_completion_test.clj
+++ b/src/test/suitable/js_completion_test.clj
@@ -174,7 +174,7 @@
            (sut/cljs-completions cljs-eval-fn "ba" {:ns "cljs.user" :context "(.. js/foo zork (__prefix__ \"foo\"))"})))))
 
 
-(deftest dotdot-completion-chained+nested
+(deftest dotdot-completion-chained+nested-2
   (let [cljs-eval-fn (fake-cljs-eval-fn "(.. js/foo zork)" "ba" [{:name "bar" :hierarchy 1 :type "var"}
                                                         {:name "baz" :hierarchy 1 :type "function"}])]
     (is (= [(candidate "-bar" "(.. js/foo zork)")]


### PR DESCRIPTION
Fixes https://github.com/clojure-emacs/clj-suitable/issues/19

These are the problems being fixed:

<details>

```
Directories scanned for source files: src/dev src/main src/test
== Linting suitable.ast ==
== Linting suitable.js-completions ==
src/main/suitable/js_completions.cljc:28:7: misplaced-docstrings: Possibly misplaced docstring, find-prefix.
src/main/suitable/js_completions.cljc:28:1: unused-ret-vals {:kind :const}: Constant value is discarded: "Tree search for the symbol '__prefix. Returns a zipper.".
src/main/suitable/js_completions.cljc:134:7: unused-ret-vals {:kind :local}: Local value is discarded: obj-expr-parts.
== Linting suitable.complete-for-nrepl ==
src/main/suitable/complete_for_nrepl.clj:112:6: reflection: reference to field getName can't be resolved.
== Linting suitable.middleware ==
== Linting suitable.nrepl ==
== Linting suitable.nrepl-figwheel ==
== Linting suitable.compliment.sources.cljs.analysis ==
== Linting suitable.js-completion-test ==
src/test/suitable/js_completion_test.clj:177:10: redefd-vars: Var dotdot-completion-chained+nested def'd 2 times at line:col locations: suitable/js_completion_test.clj:168:10 suitable/js_completion_test.clj:177:10.
== Linting suitable.compliment.sources.cljs ==
== Linting suitable.nrepl-shadow ==
== Linting suitable.complete-for-nrepl-test ==
src/test/suitable/complete_for_nrepl_test.clj:1:1: def-in-def: There is a def of suitable.complete-for-nrepl-test/handler nested inside def sanity-test-node.
src/test/suitable/complete_for_nrepl_test.clj:1:1: def-in-def: There is a def of suitable.complete-for-nrepl-test/server nested inside def sanity-test-node.
src/test/suitable/complete_for_nrepl_test.clj:1:1: def-in-def: There is a def of suitable.complete-for-nrepl-test/transport nested inside def sanity-test-node.
src/test/suitable/complete_for_nrepl_test.clj:1:1: def-in-def: There is a def of suitable.complete-for-nrepl-test/client nested inside def sanity-test-node.
src/test/suitable/complete_for_nrepl_test.clj:1:1: def-in-def: There is a def of suitable.complete-for-nrepl-test/session nested inside def sanity-test-node.
src/test/suitable/complete_for_nrepl_test.clj:1:1: def-in-def: There is a def of suitable.complete-for-nrepl-test/handler nested inside def suitable-node.
src/test/suitable/complete_for_nrepl_test.clj:1:1: def-in-def: There is a def of suitable.complete-for-nrepl-test/server nested inside def suitable-node.
src/test/suitable/complete_for_nrepl_test.clj:1:1: def-in-def: There is a def of suitable.complete-for-nrepl-test/transport nested inside def suitable-node.
src/test/suitable/complete_for_nrepl_test.clj:1:1: def-in-def: There is a def of suitable.complete-for-nrepl-test/client nested inside def suitable-node.
src/test/suitable/complete_for_nrepl_test.clj:1:1: def-in-def: There is a def of suitable.complete-for-nrepl-test/session nested inside def suitable-node.
src/test/suitable/complete_for_nrepl_test.clj:42:3: reflection: reference to field close can't be resolved.
src/test/suitable/complete_for_nrepl_test.clj:43:3: reflection: reference to field close can't be resolved.
== Linting suitable.utils ==
src/main/suitable/utils.clj:12:21: implicit-dependencies: Var cljs.repl/eval-cljs refers to namespace cljs.repl that isn't explicitly required.
== Linting suitable.hijack-rebel-readline-complete ==
== Linting suitable.scratch ==
== Linting suitable.compliment.sources.cljs.ast ==
== Linting suitable.compliment.sources.t-cljs ==
== Linting suitable.figwheel.main ==
== Linting suitable.spec ==
== Linting suitable.repl ==
== Linting done in 17478 ms ==
== Warnings: 18. Exceptions thrown: 0
```

</details>

No CI integration is introduced because the project seems to lack CI atm