### PR TITLE
Draft CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,148 @@
+version: 2.1
+
+# Default settings for executors
+
+defaults: &defaults
+  working_directory: ~/repo
+
+# Runners for OpenJDK 8/11/16
+
+executors:
+  openjdk8:
+    docker:
+      - image: circleci/clojure:openjdk-8-lein-2.9.1-node
+    environment:
+      LEIN_ROOT: "true"   # we intended to run lein as root
+      JVM_OPTS: -Xmx3200m # limit the maximum heap size to prevent out of memory errors
+    <<: *defaults
+  openjdk11:
+    docker:
+      - image: circleci/clojure:openjdk-11-lein-2.9.1-node
+    environment:
+      LEIN_ROOT: "true"   # we intended to run lein as root
+      JVM_OPTS: -Xmx3200m --illegal-access=deny # forbid reflective access
+    <<: *defaults
+  openjdk16:
+    docker:
+      - image: circleci/clojure:openjdk-16-lein-2.9.5-buster-node
+    environment:
+      LEIN_ROOT: "true"   # we intended to run lein as root
+      JVM_OPTS: -Xmx3200m --illegal-access=deny # forbid reflective access
+    <<: *defaults
+
+commands:
+  with_cache:
+    description: |
+      Run a set of steps with Maven dependencies and Clojure classpath cache
+      files cached.
+      This command restores ~/.m2 and .cpcache if they were previously cached,
+      then runs the provided steps, and finally saves the cache.
+      The cache-key is generated based on the contents of `deps.edn` present in
+      the `working_directory`.
+    parameters:
+      steps:
+        type: steps
+      files:
+        description: Files to consider when creating the cache key
+        type: string
+        default: "deps.edn project.clj build.boot"
+      cache_version:
+        type: string
+        description: "Change this value to force a cache update"
+        default: "1"
+    steps:
+      - run:
+          name: Install Clojure
+          command: |
+            wget -nc https://download.clojure.org/install/linux-install-1.10.3.855.sh
+            chmod +x linux-install-1.10.3.855.sh
+            sudo ./linux-install-1.10.3.855.sh
+      - run:
+          name: Install make
+          command: |
+            sudo apt-get install make
+      - run:
+          name: Generate Cache Checksum
+          command: |
+            for file in << parameters.files >>
+            do
+              find . -name $file -exec cat {} +
+            done | shasum | awk '{print $1}' > /tmp/clojure_cache_seed
+      - restore_cache:
+          key: clojure-<< parameters.cache_version >>-{{ checksum "/tmp/clojure_cache_seed" }}
+      - steps: << parameters.steps >>
+      - save_cache:
+          paths:
+            - ~/.m2
+            - .cpcache
+          key: clojure-<< parameters.cache_version >>-{{ checksum "/tmp/clojure_cache_seed" }}
+
+jobs:
+
+  util_job:
+    description: |
+      Running utility commands/checks (linter etc.)
+      Always uses Java11 and Clojure 1.10
+    parameters:
+      steps:
+        type: steps
+    executor: openjdk11
+    environment:
+      VERSION: "1.10"
+    steps:
+      - checkout
+      - with_cache:
+          cache_version: "1.10"
+          steps: << parameters.steps >>
+
+
+  test_code:
+    description: |
+      Run tests against given version of JDK and Clojure
+    parameters:
+      jdk_version:
+        description: Version of JDK to test against
+        type: string
+      clojure_version:
+        description: Version of Clojure to test against
+        type: string
+    executor: << parameters.jdk_version >>
+    environment:
+      VERSION: << parameters.clojure_version >>
+    steps:
+      - checkout
+      - with_cache:
+          cache_version: << parameters.clojure_version >>|<< parameters.jdk_version >>
+          steps:
+            - run:
+                name: Ensure node.js
+                command: node --version
+            - run:
+                name: Running tests
+                command: make test
+
+workflows:
+  version: 2.1
+  ci-test-matrix:
+    jobs:
+      - test_code:
+          matrix:
+            parameters:
+              # FIXME other things worth adding to the matrix:
+              # - clojurescript
+              # - cider-nrepl
+              # - node.js runtimes
+              clojure_version: ["1.8", "1.9", "1.10", "master"]
+              jdk_version: [openjdk8, openjdk11, openjdk16]
+      - util_job:
+          name: Code Linting
+          steps:
+            # FIXME satisfy then enable clj-kondo
+            ## - run:
+            ##     name: Running clj-kondo
+            ##     command: |
+            ##       clojure -M:dev-figwheel:fig-repl:dev-shadow:test:kondo
+            - run:
+                name: Running Eastwood
+                command: |
+                  clojure -M:dev-figwheel:fig-repl:dev-shadow:test:eastwood

--- a/deps.edn
+++ b/deps.edn
@@ -34,6 +34,7 @@
                                                           :sha "209b64504cb3bd3b99ecfec7937b358a879f55c1"}
                                cider/cider-nrepl {:mvn/version "0.26.0"}
                                cider/piggieback {:mvn/version "0.5.2"}}
+                  :jvm-opts ["-Dclojure.main.report=stderr"]
                   :main-opts ["-m" "cognitect.test-runner" "-d" "src/test"]}
 
            ;; build a jar, https://juxt.pro/blog/posts/pack-maven.html

--- a/deps.edn
+++ b/deps.edn
@@ -1,38 +1,39 @@
-{:deps {org.clojure/clojurescript {:mvn/version "[1.9.908,)"}
+{:deps {org.clojure/clojurescript {:mvn/version "1.10.879"}
+        org.clojure/clojure {:mvn/version "1.10.3" :scope "provided"}
         compliment/compliment {:mvn/version "0.3.10"}}
 
  :paths ["src/main"]
 
  :aliases {;; for starting nrepl clj & cljs servers for live development
            :dev-figwheel {:extra-paths ["src/dev" "resources" "target"]
-                          :extra-deps {cider/piggieback {:mvn/version "RELEASE"}
-                                       cider/cider-nrepl {:mvn/version "RELEASE"}
-                                       com.bhauman/figwheel-main {:mvn/version "RELEASE"}}
+                          :extra-deps {cider/piggieback {:mvn/version "0.5.2"}
+                                       cider/cider-nrepl {:mvn/version "0.26.0"}
+                                       com.bhauman/figwheel-main {:mvn/version "0.2.14"}}
                           :main-opts ["-m" "suitable.nrepl-figwheel"]}
 
            :dev-shadow {:extra-paths ["src/dev" "resources" "target"]
-                        :extra-deps {cider/piggieback {:mvn/version "RELEASE"}
-                                     cider/cider-nrepl {:mvn/version "RELEASE"}
-                                     thheller/shadow-cljs {:mvn/version "RELEASE"}}
+                        :extra-deps {cider/piggieback {:mvn/version "0.5.2"}
+                                     cider/cider-nrepl {:mvn/version "0.26.0"}
+                                     thheller/shadow-cljs {:mvn/version "2.15.8"}}
                         :main-opts ["-m" "suitable.nrepl-shadow"]}
 
            :fig-repl {:extra-paths ["resources" "target" "src/dev" "src/test"]
                       :main-opts ["-e" "(require,'suitable.hijack-rebel-readline-complete)"
                                   "-m" "figwheel.main" "--build" "fig" "--repl"]
-                      :extra-deps {com.bhauman/figwheel-main {:mvn/version "RELEASE"}
-                                   com.bhauman/rebel-readline-cljs {:mvn/version "RELEASE"}}}
+                      :extra-deps {com.bhauman/figwheel-main {:mvn/version "0.2.14"}
+                                   com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}}}
 
            ;; build the cljs dev stuff, optional
            :build-cljs {:extra-paths ["resources" "target" "src/dev" "src/test"]
                         :main-opts ["-m" "figwheel.main" "-b" "fig"]
-                        :extra-deps {com.bhauman/figwheel-main {:mvn/version "RELEASE"}}}
+                        :extra-deps {com.bhauman/figwheel-main {:mvn/version "0.2.14"}}}
 
            ;; tests
            :test {:extra-paths ["src/test" "resources"]
                   :extra-deps {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
                                                           :sha "209b64504cb3bd3b99ecfec7937b358a879f55c1"}
-                               cider/cider-nrepl {:mvn/version "RELEASE"}
-                               cider/piggieback {:mvn/version "RELEASE"}}
+                               cider/cider-nrepl {:mvn/version "0.26.0"}
+                               cider/piggieback {:mvn/version "0.5.2"}}
                   :main-opts ["-m" "cognitect.test-runner" "-d" "src/test"]}
 
            ;; build a jar, https://juxt.pro/blog/posts/pack-maven.html
@@ -40,7 +41,10 @@
                                                 :sha "2769a6224bfb938e777906ea311b3daf7d2220f5"}}
                   :main-opts ["-m"]}
 
-           ;; clojure -M:dev-figwheel:fig-repl:dev-shadow:test:eastwood
+           :kondo
+           {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2021.08.06"}}
+            :main-opts  ["-m" "clj-kondo.main" "--lint" "src/dev" "src/main" "src/test"]}
+
            :eastwood
            {:main-opts ["-m" "eastwood.lint" {:config-files ["eastwood.clj"]}]
             :extra-deps {org.clojure/tools.nrepl {:mvn/version "0.2.13"}

--- a/pom.xml
+++ b/pom.xml
@@ -7,25 +7,27 @@
   <name>suitable</name>
   <description>An addon for Figwheel and Emacs Cider to aid live exploratory development. Queries objects in ClojureScript for their properties to use as part of nREPL completion handlers.</description>
   <url>http://github.com/rksm/clj-suitable</url>
-
   <licenses>
     <license>
       <name>MIT License</name>
       <url>http://opensource.org/licenses/MIT</url>
     </license>
   </licenses>
-
   <developers>
     <developer>
       <name>Robert Krahn</name>
     </developer>
   </developers>
-
   <dependencies>
     <dependency>
       <groupId>org.clojure</groupId>
+      <artifactId>clojure</artifactId>
+      <version>1.10.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.clojure</groupId>
       <artifactId>clojurescript</artifactId>
-      <version>1.10.844</version>
+      <version>1.10.879</version>
     </dependency>
     <dependency>
       <groupId>compliment</groupId>
@@ -33,7 +35,6 @@
       <version>0.3.10</version>
     </dependency>
   </dependencies>
-
   <build>
     <sourceDirectory>src/main</sourceDirectory>
     <testSourceDirectory>test</testSourceDirectory>
@@ -41,22 +42,15 @@
     <outputDirectory>target/classes</outputDirectory>
     <plugins/>
   </build>
-
   <scm>
     <url>https://github.com/rksm/clj-suitable</url>
     <connection>scm:git:git://github.com/rksm/clj-suitable.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/rksm/clj-suitable.git</developerConnection>
   </scm>
-
   <repositories>
     <repository>
       <id>clojars</id>
       <url>https://repo.clojars.org/</url>
     </repository>
-    <repository>
-      <id>sonatype</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-    </repository>
   </repositories>
-
 </project>

--- a/src/test/suitable/complete_for_nrepl_test.clj
+++ b/src/test/suitable/complete_for_nrepl_test.clj
@@ -48,7 +48,7 @@
                                                 (apply default-handler))))
      (alter-var-root #'server (constantly (start-server :handler handler)))
      (alter-var-root #'transport (constantly (nrepl/connect :port (:port server))))
-     (alter-var-root #'client (constantly (nrepl/client transport 3000)))
+     (alter-var-root #'client (constantly (nrepl/client transport (:port server))))
      (alter-var-root #'session (constantly (doto (nrepl/client-session client)
                                              assert)))
      (binding [*server* server


### PR DESCRIPTION
Drafts a CI setup.

I got `make test` working locally, however it fails on Circle: https://app.circleci.com/pipelines/github/reducecombine/clj-suitable/3/workflows/8ece7e9e-fe23-42ec-a76a-15db36cb842f/jobs/36

The failure in question might ring a bell:

> `Syntax error compiling at (REPL:1:1).\nNo such namespace: js\n"`

Thoughts? @rksm 

...at first it looked like improving the `RELEASE` dependencies would fix that (it certainly did for me locally), no luck on Circle though.

Finally it would be nice to add the project to https://app.circleci.com/pipelines/github/clojure-emacs in the meantime; I can't do that and would save me the temp fork. @bbatsov 