### PR TITLE
Fix `node-env?`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 * [#22](https://github.com/clojure-emacs/clj-suitable/issues/22): Gracefully handle string requires.
+* [#14](https://github.com/clojure-emacs/clj-suitable/issues/14): Fix a NullPointerException / Fix Node.js detection
 
 ## 0.4.0 (2021-04-18)
 

--- a/src/test/suitable/complete_for_nrepl_test.clj
+++ b/src/test/suitable/complete_for_nrepl_test.clj
@@ -1,10 +1,12 @@
 (ns suitable.complete-for-nrepl-test
-  (:require [clojure.test :as t :refer [deftest is run-tests testing]]
-            [clojure.java.shell]
-            [cider.piggieback :as piggieback]
-            [nrepl.core :as nrepl]
-            [nrepl.server :refer [start-server default-handler]]
-            [suitable.middleware :refer [wrap-complete-standalone]]))
+  (:require
+   [cider.piggieback :as piggieback]
+   [clojure.java.shell]
+   [clojure.test :as t :refer [deftest is run-tests testing]]
+   [nrepl.core :as nrepl]
+   [nrepl.server :refer [start-server default-handler]]
+   [suitable.complete-for-nrepl :as sut]
+   [suitable.middleware :refer [wrap-complete-standalone]]))
 
 (require 'cljs.repl)
 (require 'cljs.repl.node)
@@ -102,6 +104,13 @@
             candidates (:completions response)]
         (is (= [{:ns "js/Object", :candidate ".keys" :type "function"}] candidates)
             (pr-str response))))))
+
+(deftest node-env?
+  (is (false? (sut/node-env? nil)))
+  (is (false? (sut/node-env? 42)))
+  (is (sut/node-env? (cljs.repl.node/repl-env)))
+  ;; Exercise `piggieback/generate-delegating-repl-env` because it's mentioned in the docstring of `sut/node-env?`:
+  (is (sut/node-env? (#'piggieback/generate-delegating-repl-env (cljs.repl.node/repl-env)))))
 
 (comment
   (run-tests))


### PR DESCRIPTION
Makes it nil-safe, while taking care of not comparing nil to nil.

It also fixes edge cases making it work as intended over various auto-generated classes.

Fixes https://github.com/clojure-emacs/clj-suitable/issues/14