### PR TITLE
Don't run side-effects for pure-clojurescript (non-interop) `->` chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+* [#30](https://github.com/clojure-emacs/clj-suitable/issues/30): don't run side-effects for pure-clojurescript (non-interop) `->` chains.
+
 ## 0.4.1 (2021-10-02)
 
 * [#22](https://github.com/clojure-emacs/clj-suitable/issues/22): Gracefully handle string requires.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The dynamic code completion features allow for exploratory development by inspec
 
 The dynamic code completion *evaluates* code on completion requests! It does this by trying to [enumerate the properties](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptors) of JavaScript objects, so in the example above it would fetch all properties of the `js/document` object. This might cause side effects: Even just reading property values of an object can run arbitrary code if that object defines getter functions.
 
-Moreover, also chains of methods and properties will be evaluated upon completion requests. So for example, asking for completions for the code / cursor position `(-> js/some-object (.deleteAllMyFilesAndStartAWar) .|)` will evaluate the JavaScript code `some-object.deleteAllMyFilesAndStartAWar()`! This only applies to JavaSript interop code, i.e. JavaScript methods and properties. Pure ClojureScript is not inspected or evaluated. Please be aware of this behavior when using the dynamic code completion features.
+Moreover, also chains of methods and properties will be evaluated upon completion requests. So for example, asking for completions for the code / cursor position `(-> js/some-object (.deleteAllMyFilesAndStartAWar) .|)` will evaluate the JavaScript code `some-object.deleteAllMyFilesAndStartAWar()`! This only applies to JavaScript interop code, i.e. JavaScript methods and properties. Pure ClojureScript is not inspected or evaluated. Please be aware of this behavior when using the dynamic code completion features.
 
 ### Dynamic completion Demo
 
@@ -152,7 +152,15 @@ Or from within Clojure:
 suitable uses the same input as the widely used
 [compliment](https://github.com/alexander-yakushev/compliment). This means it gets a prefix string and a context form from the tool it is connected to. For example you type `(.l| js/console)` with "|" marking where your cursor is. The input we get would then be: prefix = `.l` and context = `(__prefix__ js/console)`.
 
-suitable recognizes various ways how CLJS can access properties and methods, such as `.`, `..`, `doto`, and threading forms. Also direct global access is supported such as `js/console.log`. suitable will then figure out the expression that defines the "parent object" that the property / method we want to use belongs to. For the example above it would be `js/console`. The system then uses the [EcmaScript property descriptor API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty) to enumerate the object members. Those are converted into completion candidates and send back to the tooling.
+suitable recognizes various ways how CLJS can access properties and methods, such as:
+
+* `.`,
+* `..`
+* `doto`
+* threading forms
+  * For this specific case, evaluation-based (side-effectful) code completion will be only performed if the threading form appears to deal with js objects. 
+
+Also, direct global access is supported such as `js/console.log`. suitable will then figure out the expression that defines the "parent object" that the property / method we want to use belongs to. For the example above it would be `js/console`. The system then uses the [EcmaScript property descriptor API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty) to enumerate the object members. Those are converted into completion candidates and send back to the tooling.
 
 ## License
 

--- a/src/test/suitable/js_completion_test.clj
+++ b/src/test/suitable/js_completion_test.clj
@@ -1,8 +1,9 @@
 (ns suitable.js-completion-test
-  (:require [clojure.pprint :refer [cl-format]]
-            [clojure.string :refer [starts-with?]]
-            [clojure.test :as t :refer [deftest is testing]]
-            [suitable.js-completions :as sut]))
+  (:require
+   [clojure.pprint :refer [cl-format]]
+   [clojure.string :refer [starts-with?]]
+   [clojure.test :as t :refer [are deftest is testing]]
+   [suitable.js-completions :as sut]))
 
 ;; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 ;; helpers
@@ -13,9 +14,9 @@
                               (re-find #"^(?:js/|\.-|-)" completion) "var"
                               (starts-with? completion ".") "function"
                               :else "function")))
+
   ([completion ns type]
    {:type type, :candidate completion :ns ns}))
-
 
 (defn fake-cljs-eval-fn [expected-obj-expression expected-prefix properties]
   (fn [_ns code]
@@ -27,99 +28,108 @@
                (= prefix expected-prefix))
         {:error nil
          :value properties}
-        (is false (cl-format nil "expected obj-expr / prefix~% ~S / ~S~% passed to fake-js-props-fn does not match actual expr / prefix~% ~S / ~S"
-                             expected-obj-expression expected-prefix
-                             obj-expr prefix))))))
+        (is false
+            (cl-format nil
+                       "expected obj-expr / prefix~% ~S / ~S~% passed to fake-js-props-fn does not match actual expr / prefix~% ~S / ~S"
+                       expected-obj-expression expected-prefix
+                       obj-expr prefix))))))
 
 ;; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 ;; expr-for-parent-obj
 
 (deftest expr-for-parent-obj
-  (let [tests [ ;; should not trigger object completion
-               {:desc "no object in sight"
-                :symbol-and-context    [".log" "(__prefix__)"]
-                :expected nil}
+  (testing "Finds an expression that evaluates to the object being accessed"
+    (let [tests [;; should not trigger object completion
+                 {:desc               "no object in sight"
+                  :symbol-and-context [".log" "(__prefix__)"]
+                  :expected           nil}
 
-               {:desc "Normal object/class name is typed, not method or special name."
-                :symbol-and-context    ["bar" "(.log __prefix__)"]
-                :expected nil}
+                 {:desc               "The user typed a normal object/class name, not a method or special name."
+                  :symbol-and-context ["bar" "(.log __prefix__)"]
+                  :expected           nil}
 
-               ;; should trigger object completion
-               {:desc ". method"
-                :symbol-and-context    [".log" "(__prefix__ js/console)"]
-                :expected {:type :. :obj-expr "js/console"}}
+                 ;; should trigger object completion
+                 {:desc               ". method"
+                  :symbol-and-context [".log" "(__prefix__ js/console)"]
+                  :expected           {:type :. :obj-expr "js/console"}}
 
-               {:desc ". method nested"
-                :symbol-and-context    [".log" "(__prefix__ (.-console js/window) \"foo\")"]
-                :expected {:type :. :obj-expr "(.-console js/window)"}}
+                 {:desc               ". method nested"
+                  :symbol-and-context [".log" "(__prefix__ (.-console js/window) \"foo\")"]
+                  :expected           {:type :. :obj-expr "(.-console js/window)"}}
 
-               {:desc ".- prop"
-                :symbol-and-context    [".-memory" "(__prefix__ js/console)"]
-                :expected {:type :. :obj-expr "js/console"}}
+                 {:desc               ".- prop"
+                  :symbol-and-context [".-memory" "(__prefix__ js/console)"]
+                  :expected           {:type :. :obj-expr "js/console"}}
 
-               {:desc ".- prop nested"
-                :symbol-and-context    [".-memory" "(__prefix__ (.-console js/window) \"foo\")"]
-                :expected {:type :. :obj-expr "(.-console js/window)"}}
+                 {:desc               ".- prop nested"
+                  :symbol-and-context [".-memory" "(__prefix__ (.-console js/window) \"foo\")"]
+                  :expected           {:type :. :obj-expr "(.-console js/window)"}}
 
-               {:desc ".. method"
-                :symbol-and-context    ["log" "(.. js/console __prefix__)"]
-                :expected {:type :.. :obj-expr "js/console"}}
+                 {:desc               ".. method"
+                  :symbol-and-context ["log" "(.. js/console __prefix__)"]
+                  :expected           {:type :.. :obj-expr "js/console"}}
 
-               {:desc ".. method nested"
-                :symbol-and-context    ["log" "(.. js/console (__prefix__ \"foo\"))"]
-                :expected {:type :.. :obj-expr "js/console"}}
+                 {:desc               ".. method nested"
+                  :symbol-and-context ["log" "(.. js/console (__prefix__ \"foo\"))"]
+                  :expected           {:type :.. :obj-expr "js/console"}}
 
-               {:desc ".. method chained"
-                :symbol-and-context    ["log" "(.. js/window -console __prefix__)"]
-                :expected {:type :.. :obj-expr "(.. js/window -console)"}}
+                 {:desc               ".. method chained"
+                  :symbol-and-context ["log" "(.. js/window -console __prefix__)"]
+                  :expected           {:type :.. :obj-expr "(.. js/window -console)"}}
 
-               {:desc ".. method chained and nested"
-                :symbol-and-context    ["log" "(.. js/window -console (__prefix__ \"foo\"))"]
-                :expected {:type :.. :obj-expr "(.. js/window -console)"}}
+                 {:desc               ".. method chained and nested"
+                  :symbol-and-context ["log" "(.. js/window -console (__prefix__ \"foo\"))"]
+                  :expected           {:type :.. :obj-expr "(.. js/window -console)"}}
 
-               {:desc ".. prop"
-                :symbol-and-context    ["-memory" "(.. js/console __prefix__)"]
-                :expected {:type :.. :obj-expr "js/console"}}
+                 {:desc               ".. prop"
+                  :symbol-and-context ["-memory" "(.. js/console __prefix__)"]
+                  :expected           {:type :.. :obj-expr "js/console"}}
 
-               {:desc "->"
-                :symbol-and-context    [".log" "(-> js/console __prefix__)"]
-                :expected {:type :-> :obj-expr "(-> js/console)"}}
+                 {:desc               "-> (first member of the chain is a constant)"
+                  :symbol-and-context [".log" "(-> 52 __prefix__)"]
+                  :expected           {:type :-> :obj-expr "(-> 52)"}}
 
-               {:desc "-> (.)"
-                :symbol-and-context    [".log" "(-> js/console (__prefix__ \"foo\"))"]
-                :expected {:type :-> :obj-expr "(-> js/console)"}}
+                 {:desc               "->"
+                  :symbol-and-context [".log" "(-> js/console __prefix__)"]
+                  :expected           {:type :-> :obj-expr "(-> js/console)"}}
 
-               {:desc "-> chained"
-                :symbol-and-context    [".log" "(-> js/window .-console __prefix__)"]
-                :expected {:type :-> :obj-expr "(-> js/window .-console)"}}
+                 {:desc               "-> (.)"
+                  :symbol-and-context [".log" "(-> js/console (__prefix__ \"foo\"))"]
+                  :expected           {:type :-> :obj-expr "(-> js/console)"}}
 
-               {:desc "-> (.)"
-                :symbol-and-context    [".log" "(-> js/window .-console (__prefix__ \"foo\"))"]
-                :expected {:type :-> :obj-expr "(-> js/window .-console)"}}
+                 {:desc               "-> chained"
+                  :symbol-and-context [".log" "(-> js/window .-console __prefix__)"]
+                  :expected           {:type :-> :obj-expr "(-> js/window .-console)"}}
 
-               {:desc "doto"
-                :symbol-and-context    [".log" "(doto (. js/window -console) __prefix__)"]
-                :expected {:type :doto :obj-expr "(. js/window -console)"}}
+                 {:desc               "-> (.)"
+                  :symbol-and-context [".log" "(-> js/window .-console (__prefix__ \"foo\"))"]
+                  :expected           {:type :-> :obj-expr "(-> js/window .-console)"}}
 
-               {:desc "doto (.)"
-                :symbol-and-context    [".log" "(doto (. js/window -console) (__prefix__ \"foo\"))"]
-                :expected {:type :doto :obj-expr "(. js/window -console)"}}
+                 {:desc               "doto"
+                  :symbol-and-context [".log" "(doto (. js/window -console) __prefix__)"]
+                  :expected           {:type :doto :obj-expr "(. js/window -console)"}}
 
-               {:desc "doto (.)"
-                :symbol-and-context    ["js/cons" "(doto (. js/window -console) (__prefix__ \"foo\"))"]
-                :expected {:type :doto :obj-expr "(. js/window -console)"}}
+                 {:desc               "doto (.)"
+                  :symbol-and-context [".log" "(doto (. js/window -console) (__prefix__ \"foo\"))"]
+                  :expected           {:type :doto :obj-expr "(. js/window -console)"}}
 
-               {:desc "no prefix"
-                :symbol-and-context    ["xx" "(foo bar (baz))"]
-                :expected nil}
+                 {:desc               "doto (.)"
+                  :symbol-and-context ["js/cons" "(doto (. js/window -console) (__prefix__ \"foo\"))"]
+                  :expected           {:type :doto :obj-expr "(. js/window -console)"}}
 
-               {:desc "broken form"
-                :symbol-and-context    ["xx" "(foo "]
-                :expected nil}]]
+                 {:desc               "no prefix"
+                  :symbol-and-context ["xx" "(foo bar (baz))"]
+                  :expected           nil}
 
-    (doseq [{[symbol context] :symbol-and-context :keys [expected desc]} tests]
-      (is (= expected (sut/expr-for-parent-obj symbol context)) desc))))
+                 {:desc               "broken form"
+                  :symbol-and-context ["xx" "(foo "]
+                  :expected           nil}]]
 
+      (doseq [{[symbol context] :symbol-and-context :keys [expected desc]} tests]
+        (is (= expected
+               (dissoc (sut/expr-for-parent-obj symbol context)
+                       :js-interop?))
+            desc)))))
 
 ;; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 ;; cljs-completions
@@ -157,6 +167,106 @@
     (is (= [(candidate "log" "js/console")]
            (sut/cljs-completions cljs-eval-fn "l" {:ns "cljs.user" :context '(.. js/console (__prefix__ "foo"))})))))
 
+(deftest thread-first-completion
+  (let [cljs-eval-fn (fake-cljs-eval-fn "(-> js/foo)" "ba" [{:name "bar" :hierarchy 1 :type "var"}
+                                                            {:name "baz" :hierarchy 1 :type "function"}])]
+    (is (= [(candidate ".-bar" "(-> js/foo)")]
+           (sut/cljs-completions cljs-eval-fn ".-ba" {:ns "cljs.user" :context "(-> js/foo __prefix__)"})))))
+
+(deftest analyze-symbol-and-context
+  (are [context expected] (= expected
+                             (select-keys (sut/analyze-symbol-and-context ".-ba" context)
+                                          [:type :js-interop? :obj-expr]))
+    "(-> 42 __prefix__)"                             {:type :->, :js-interop? false, :obj-expr "(-> 42)"}
+    "(-> foo __prefix__)"                            {:type :->, :js-interop? false, :obj-expr "(-> foo)"}
+    "(-> 42 (__prefix__))"                           {:type :->, :js-interop? false, :obj-expr "(-> 42)"}
+    "(-> foo (__prefix__))"                          {:type :->, :js-interop? false, :obj-expr "(-> foo)"}
+    "(-> 42 (__prefix__ 42))"                        {:type :->, :js-interop? false, :obj-expr "(-> 42)"}
+    "(-> foo (__prefix__ 42))"                       {:type :->, :js-interop? false, :obj-expr "(-> foo)"}
+    "(-> 42 __prefix__ FOO)"                         {:type :->, :js-interop? false, :obj-expr "(-> 42)"}
+    "(-> foo __prefix__ FOO)"                        {:type :->, :js-interop? false, :obj-expr "(-> foo)"}
+    "(-> 42 (__prefix__) FOO)"                       {:type :->, :js-interop? false, :obj-expr "(-> 42)"}
+    "(-> foo (__prefix__) FOO)"                      {:type :->, :js-interop? false, :obj-expr "(-> foo)"}
+    "(-> 42 (__prefix__ 42) FOO)"                    {:type :->, :js-interop? false, :obj-expr "(-> 42)"}
+    "(-> foo (__prefix__ 42) FOO)"                   {:type :->, :js-interop? false, :obj-expr "(-> foo)"}
+    "(-> js/foo __prefix__)"                         {:type :->, :js-interop? true, :obj-expr "(-> js/foo)"}
+    "(-> (js/foo) __prefix__)"                       {:type :->, :js-interop? true, :obj-expr "(-> (js/foo))"}
+    "(-> (js/foo 42) __prefix__)"                    {:type :->, :js-interop? true, :obj-expr "(-> (js/foo 42))"}
+    "(-> (js/foo 42) (__prefix__))"                  {:type :->, :js-interop? true, :obj-expr "(-> (js/foo 42))"}
+    "(-> (js/foo 42) (__prefix__ 42))"               {:type :->, :js-interop? true, :obj-expr "(-> (js/foo 42))"}
+    "(-> (js/foo 42) (__prefix__ 42) FOO)"           {:type :->, :js-interop? true, :obj-expr "(-> (js/foo 42))"}
+    "(->> 42 __prefix__)"                            {:type :->, :js-interop? false, :obj-expr "(->> 42)"}
+    "(->> foo __prefix__)"                           {:type :->, :js-interop? false, :obj-expr "(->> foo)"}
+    "(->> 42 (__prefix__))"                          {:type :->, :js-interop? false, :obj-expr "(->> 42)"}
+    "(->> foo (__prefix__))"                         {:type :->, :js-interop? false, :obj-expr "(->> foo)"}
+    "(->> 42 (__prefix__ 42))"                       {:type :->, :js-interop? false, :obj-expr "(->> 42)"}
+    "(->> foo (__prefix__ 42))"                      {:type :->, :js-interop? false, :obj-expr "(->> foo)"}
+    "(->> 42 __prefix__ FOO)"                        {:type :->, :js-interop? false, :obj-expr "(->> 42)"}
+    "(->> foo __prefix__ FOO)"                       {:type :->, :js-interop? false, :obj-expr "(->> foo)"}
+    "(->> 42 (__prefix__) FOO)"                      {:type :->, :js-interop? false, :obj-expr "(->> 42)"}
+    "(->> foo (__prefix__) FOO)"                     {:type :->, :js-interop? false, :obj-expr "(->> foo)"}
+    "(->> 42 (__prefix__ 42) FOO)"                   {:type :->, :js-interop? false, :obj-expr "(->> 42)"}
+    "(->> foo (__prefix__ 42) FOO)"                  {:type :->, :js-interop? false, :obj-expr "(->> foo)"}
+    "(->> js/foo __prefix__)"                        {:type :->, :js-interop? true, :obj-expr "(->> js/foo)"}
+    "(->> (js/foo) __prefix__)"                      {:type :->, :js-interop? true, :obj-expr "(->> (js/foo))"}
+    "(->> (js/foo 42) __prefix__)"                   {:type :->, :js-interop? true, :obj-expr "(->> (js/foo 42))"}
+    "(->> (js/foo 42) (__prefix__))"                 {:type :->, :js-interop? true, :obj-expr "(->> (js/foo 42))"}
+    "(->> (js/foo 42) (__prefix__ 42))"              {:type :->, :js-interop? true, :obj-expr "(->> (js/foo 42))"}
+    "(->> (js/foo 42) (__prefix__ 42) FOO)"          {:type :->, :js-interop? true, :obj-expr "(->> (js/foo 42))"}
+    "(doto 42 __prefix__)"                           {:type :doto, :js-interop? true, :obj-expr "42"}
+    "(doto foo __prefix__)"                          {:type :doto, :js-interop? true, :obj-expr "foo"}
+    "(doto 42 (__prefix__))"                         {:type :doto, :js-interop? true, :obj-expr "42"}
+    "(doto foo (__prefix__))"                        {:type :doto, :js-interop? true, :obj-expr "foo"}
+    "(doto 42 (__prefix__ 42))"                      {:type :doto, :js-interop? true, :obj-expr "42"}
+    "(doto foo (__prefix__ 42))"                     {:type :doto, :js-interop? true, :obj-expr "foo"}
+    "(doto 42 __prefix__ FOO)"                       {:type :doto, :js-interop? true, :obj-expr "42"}
+    "(doto foo __prefix__ FOO)"                      {:type :doto, :js-interop? true, :obj-expr "foo"}
+    "(doto 42 (__prefix__) FOO)"                     {:type :doto, :js-interop? true, :obj-expr "42"}
+    "(doto foo (__prefix__) FOO)"                    {:type :doto, :js-interop? true, :obj-expr "foo"}
+    "(doto 42 (__prefix__ 42) FOO)"                  {:type :doto, :js-interop? true, :obj-expr "42"}
+    "(doto foo (__prefix__ 42) FOO)"                 {:type :doto, :js-interop? true, :obj-expr "foo"}
+    "(doto js/foo __prefix__)"                       {:type :doto, :js-interop? true, :obj-expr "js/foo"}
+    "(doto (js/foo) __prefix__)"                     {:type :doto, :js-interop? true, :obj-expr "(js/foo)"}
+    "(doto (js/foo 42) __prefix__)"                  {:type :doto, :js-interop? true, :obj-expr "(js/foo 42)"}
+    "(doto (js/foo 42) (__prefix__))"                {:type :doto, :js-interop? true, :obj-expr "(js/foo 42)"}
+    "(doto (js/foo 42) (__prefix__ 42))"             {:type :doto, :js-interop? true, :obj-expr "(js/foo 42)"}
+    "(doto (js/foo 42) (__prefix__ 42) FOO)"         {:type :doto, :js-interop? true, :obj-expr "(js/foo 42)"}
+    "(doto 42 bar baz __prefix__)"                   {:type :doto, :js-interop? true, :obj-expr "42"}
+    "(doto foo bar baz __prefix__)"                  {:type :doto, :js-interop? true, :obj-expr "foo"}
+    "(doto 42 bar baz (__prefix__))"                 {:type :doto, :js-interop? true, :obj-expr "42"}
+    "(doto foo bar baz (__prefix__))"                {:type :doto, :js-interop? true, :obj-expr "foo"}
+    "(doto 42 bar baz (__prefix__ 42))"              {:type :doto, :js-interop? true, :obj-expr "42"}
+    "(doto foo bar baz (__prefix__ 42))"             {:type :doto, :js-interop? true, :obj-expr "foo"}
+    "(doto 42 bar baz __prefix__ FOO)"               {:type :doto, :js-interop? true, :obj-expr "42"}
+    "(doto foo bar baz __prefix__ FOO)"              {:type :doto, :js-interop? true, :obj-expr "foo"}
+    "(doto 42 bar baz (__prefix__) FOO)"             {:type :doto, :js-interop? true, :obj-expr "42"}
+    "(doto foo bar baz (__prefix__) FOO)"            {:type :doto, :js-interop? true, :obj-expr "foo"}
+    "(doto 42 bar baz (__prefix__ 42) FOO)"          {:type :doto, :js-interop? true, :obj-expr "42"}
+    "(doto foo bar baz (__prefix__ 42) FOO)"         {:type :doto, :js-interop? true, :obj-expr "foo"}
+    "(doto js/foo bar baz __prefix__)"               {:type :doto, :js-interop? true, :obj-expr "js/foo"}
+    "(doto (js/foo) bar baz __prefix__)"             {:type :doto, :js-interop? true, :obj-expr "(js/foo)"}
+    "(doto (js/foo 42) bar baz __prefix__)"          {:type :doto, :js-interop? true, :obj-expr "(js/foo 42)"}
+    "(doto (js/foo 42) bar baz (__prefix__))"        {:type :doto, :js-interop? true, :obj-expr "(js/foo 42)"}
+    "(doto (js/foo 42) bar baz (__prefix__ 42))"     {:type :doto, :js-interop? true, :obj-expr "(js/foo 42)"}
+    "(doto (js/foo 42) bar baz (__prefix__ 42) FOO)" {:type :doto, :js-interop? true, :obj-expr "(js/foo 42)"}
+    "(. foo __prefix__)"                             {:type :.., :js-interop? true, :obj-expr "foo"}
+    "(. foo __prefix__ 42)"                          {:type :.., :js-interop? true, :obj-expr "foo"}
+    "(. js/a __prefix__)"                            {:type :.., :js-interop? true, :obj-expr "js/a"}
+    "(. js/a __prefix__ 42)"                         {:type :.., :js-interop? true, :obj-expr "js/a"}
+    "(. (js/a) __prefix__)"                          {:type :.., :js-interop? true, :obj-expr "(js/a)"}
+    "(. (js/a 42) __prefix__)"                       {:type :.., :js-interop? true, :obj-expr "(js/a 42)"}
+    "(. (js/a 42) __prefix__ 42)"                    {:type :.., :js-interop? true, :obj-expr "(js/a 42)"}
+    "(.. foo __prefix__)"                            {:type :.., :js-interop? true, :obj-expr "foo"}
+    "(.. foo __prefix__ foo)"                        {:type :.., :js-interop? true, :obj-expr "foo"}
+    "(.. foo __prefix__ (foo 42))"                   {:type :.., :js-interop? true, :obj-expr "foo"}
+    "(.. js/a __prefix__)"                           {:type :.., :js-interop? true, :obj-expr "js/a"}
+    "(.. js/a __prefix__ foo)"                       {:type :.., :js-interop? true, :obj-expr "js/a"}
+    "(.. js/a __prefix__ (foo 42))"                  {:type :.., :js-interop? true, :obj-expr "js/a"}
+    "(.. (js/a) __prefix__)"                         {:type :.., :js-interop? true, :obj-expr "(js/a)"}
+    "(.. (js/a 42) __prefix__)"                      {:type :.., :js-interop? true, :obj-expr "(js/a 42)"}
+    "(.. (js/a 42) __prefix__ foo)"                  {:type :.., :js-interop? true, :obj-expr "(js/a 42)"}
+    "(.. (js/a 42) __prefix__ (foo 42))"             {:type :.., :js-interop? true, :obj-expr "(js/a 42)"}))
+
 (deftest dotdot-completion
   (let [cljs-eval-fn (fake-cljs-eval-fn "js/foo" "ba" [{:name "bar" :hierarchy 1 :type "var"}
                                                        {:name "baz" :hierarchy 1 :type "function"}])]
@@ -172,7 +282,6 @@
            (sut/cljs-completions cljs-eval-fn "-ba" {:ns "cljs.user" :context "(.. js/foo zork (__prefix__ \"foo\"))"})))
     (is (= [(candidate "baz" "(.. js/foo zork)")]
            (sut/cljs-completions cljs-eval-fn "ba" {:ns "cljs.user" :context "(.. js/foo zork (__prefix__ \"foo\"))"})))))
-
 
 (deftest dotdot-completion-chained+nested-2
   (let [cljs-eval-fn (fake-cljs-eval-fn "(.. js/foo zork)" "ba" [{:name "bar" :hierarchy 1 :type "var"}
@@ -201,6 +310,4 @@
   (sut/expr-for-parent-obj {:ns "cljs.user" :symbol ".l" :context "(__prefix__ js/console)"})
 
   (with-redefs [sut/js-properties-of-object (fn [obj-expr msg] [])]
-    (sut/cljs-completions {:ns "cljs.user" :symbol ".l" :context "(__prefix__ js/console)"} nil))
-
-  )
+    (sut/cljs-completions {:ns "cljs.user" :symbol ".l" :context "(__prefix__ js/console)"} nil)))


### PR DESCRIPTION
> Fixes https://github.com/clojure-emacs/clj-suitable/issues/30

The introduced logic is as follows:

* If the 'operand' of a `(-> )` (i.e. its first member) does not match `js/*` or `js/*`, then evaluation (side-effects) will shortcircuited.
* For `(. ,,,)`, `(.. ,,,)`, `(doto ,,,)`, evaluation will never be shortcircuited, because those macros are interop-oriented.

It's not perfect, but it seems to find a balance between shortcircuiting most pure clojurescript forms, and allow JS completions to still work for many cases.

In a future, logic may be refined by leveraging the cljs analyzer - we already do in cider-nrepl so it should be at hand.

Cheers - V