### PR TITLE
Enable completion for non-namespaced keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Expand completion for non-namespaced keywords.
+
 ## 0.5.0 (2023-07-28)
 
 * [#30](https://github.com/clojure-emacs/clj-suitable/issues/30): don't run side-effects for pure-clojurescript (non-interop) `->` chains.

--- a/resources/suitable/test_ns.cljs
+++ b/resources/suitable/test_ns.cljs
@@ -9,6 +9,11 @@
 
 (def x ::some-namespaced-keyword)
 
+(def foo
+  {:one   "one"
+   :two   "two"
+   :three "three"})
+
 (defn issue-28
   []
   (str "https://github.com/clojure-emacs/cljs-tooling/issues/28"))

--- a/resources/suitable/test_ns_dep.cljs
+++ b/resources/suitable/test_ns_dep.cljs
@@ -8,3 +8,6 @@
 (defn foo-in-dep [foo] :bar)
 
 (def x ::dep-namespaced-keyword)
+
+(def bar-in-dep
+  {:four "four"})

--- a/src/main/suitable/compliment/sources/cljs/analysis.clj
+++ b/src/main/suitable/compliment/sources/cljs/analysis.clj
@@ -195,9 +195,9 @@
   "Returns a list of both keyword constants in the environment and
   language specific ones."
   [env]
-  ;; using namespace for backward compatibility with Clojure 1.8
-  ;; use qualified-keyword? at some point in the future
-  (concat language-keywords (filter namespace (keys (:cljs.analyzer/constant-table env)))))
+  (into language-keywords
+        (filter keyword?)
+        (keys (:cljs.analyzer/constant-table env))))
 
 ;; grabbing directly from cljs.analyzer.api
 

--- a/src/test/suitable/compliment/sources/t_cljs.clj
+++ b/src/test/suitable/compliment/sources/t_cljs.clj
@@ -219,6 +219,14 @@
                                        {:candidate ":require-macros" :type :keyword}))
                                 (set (completions ":re")))) "the completion should include ClojureScript-specific keywords."))
 
+  (testing "Local keyword"
+    (is (= '({:candidate ":one" :type :keyword})
+           (completions ":on" 'suitable.test-ns))))
+
+  (testing "Keyword from another namespace"
+    (is (= '({:candidate ":four" :type :keyword})
+           (completions ":fo" 'suitable.test-ns))))
+
   (testing "Local namespaced keyword"
     (is (= '({:candidate "::some-namespaced-keyword" :ns "suitable.test-ns" :type :keyword})
            (completions "::so" 'suitable.test-ns)))


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)

Thanks!

### Summary

Not sure if it was a bug of a feature, but completion worked only for namespaced keywords. For clojure in CIDER completion works for all known keywords. This PR enables keywords completion for clojurescript. All existing tests pass. I also tested it locally with CIDER and it works well.
