### PR TITLE
Filter out enumerable from JS completion candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- [#39](https://github.com/clojure-emacs/clj-suitable/issues/39): Exclude enumerable from JS completion candidates.
+
 ## 0.5.1 (2023-10-31)
 
 - [#41](https://github.com/clojure-emacs/clj-suitable/pull/41): Expand completion for non-namespaced keywords.

--- a/src/main/suitable/js_introspection.cljs
+++ b/src/main/suitable/js_introspection.cljs
@@ -28,6 +28,7 @@
      (for [[i {:keys [_obj props]}] (map-indexed vector (properties-by-prototype js-obj))
            key (js-keys props)
            :when (and (not (get @seen key))
+                      (not (oget (oget props key) "enumerable"))
                       (or (empty? prefix)
                           (starts-with? key prefix)))]
        (let [prop (oget props key)]


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)

Thanks!

### Summary

Candidates like `.-0`, `.-1` etc were visible, because we didn't exclude `enumerable` properties from JS objects:

![image](https://github.com/clojure-emacs/clj-suitable/assets/6093590/b26868ce-62c8-48b9-94ed-012b9ca209d5)


In JS such properties can be used to access array elements by index (also applicable for strings) - `"abc"[0] => 'a'`.

Close #39 