### PR TITLE
Consider :reader-aliases for completion referred keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+- [#44](https://github.com/clojure-emacs/clj-suitable/pull/44): More robust completion for referred keywords. If namespace is
+  required using `:as-alias`, completion candidates were missing for
+  some CLJS environments.
+
 ## 0.6.0 (2023-11-05)
 
 - [#39](https://github.com/clojure-emacs/clj-suitable/issues/39): Exclude enumerable from JS completion candidates.

--- a/src/main/suitable/compliment/sources/cljs/analysis.clj
+++ b/src/main/suitable/compliment/sources/cljs/analysis.clj
@@ -66,11 +66,13 @@
   "Returns a map {ns-name-or-alias ns-name} for the given namespace."
   [env ns]
   (when-let [found (find-ns env ns)]
-    (let [imports    (:imports found)
-          as-aliases (get found :as-aliases {})]
-      (into as-aliases
-            (remove #(contains? imports (key %)))
-            (:requires found)))))
+    (let [imports (:imports found)]
+      (into {}
+            (comp cat (remove #(contains? imports (key %))))
+            (vals (select-keys found
+                               [:requires
+                                :as-aliases
+                                :reader-aliases]))))))
 
 (defn macro-ns-aliases
   "Returns a map of [macro-ns-name-or-alias] to [macro-ns-name] for the given namespace."


### PR DESCRIPTION
This is an extension of the previous PR. Sometimes aliased keywords are stored under :reader-aliases key, so we should also check if some aliased are available there.

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s). I've tested it locally on a real project, but I don't know how to generate a cljs-env with required namespace structure.
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)

Thanks!

### Summary

Small follow up for my previous PR.

I've been testing my previous PR on a real project and it turned out that aliased namespaces can be stored under `:reader-aliases` key (previously I only considered `:as-aliases` key). Not sure what's the difference between testing environment in this project and a real one.