### PR TITLE
Add a shadow-cljs integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,9 +79,40 @@ jobs:
       - name: Eastwood
         run: make eastwood
 
+  shadow-test:
+    name: shadow-cljs integration test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          # shadow-cljs 3.x requires JDK 21.
+          java-version: 21
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+      - uses: DeLaGuardo/setup-clojure@12.5
+        with:
+          cli: latest
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            .cpcache
+          key: deps-${{ hashFiles('deps.edn') }}
+          restore-keys: deps-
+      # the shadow-cljs Node runtime needs the `ws` package (see package.json)
+      - name: Install Node dependencies
+        run: npm install
+      - name: Run shadow-cljs integration test
+        run: clojure -M:shadow-test
+
   deploy:
     name: Deploy to Clojars
-    needs: [test, lint]
+    needs: [test, lint, shadow-test]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .clj-kondo/.cache/
 .eastwood
 .nrepl-port
+/node_modules/
 pom.xml
 /.calva/output-window/*.calva-repl
 /.cljs_nashorn_repl/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Drop the ancient Clojure 1.8/1.9/1.10 rows from the CI matrix; test against 1.11, 1.12 and master instead.
 - Migrate CI from CircleCI to GitHub Actions.
 - Replace the Leiningen/`lein-git-down` build with a `deps.edn`-native `tools.build` build (see `build.clj`).
+- Add a shadow-cljs integration test covering dynamic completion over a real Node runtime.
 
 ## 0.6.2 (2024-01-14)
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean test install deploy nrepl fig-repl kondo eastwood lint
+.PHONY: clean test shadow-test install deploy nrepl fig-repl kondo eastwood lint
 
 VERSION ?= 1.12
 
@@ -13,6 +13,12 @@ clean:
 
 test: clean
 	clojure -M:test:test-runner:$(VERSION)
+
+# shadow-cljs integration test - needs JDK 21 and a Node runtime (installs the
+# `ws` package from package.json first).
+shadow-test:
+	npm install
+	clojure -M:shadow-test
 
 kondo:
 	clojure -M:dev-figwheel:fig-repl:dev-shadow:test:kondo

--- a/deps.edn
+++ b/deps.edn
@@ -47,6 +47,15 @@
                                                                  :sha     "3f288f1f16d167723ad87cc35b1dfee3c1681e10"}}
                          :main-opts  ["-m" "cognitect.test-runner" "-d" "src/test"]}
 
+           ;; shadow-cljs integration test - needs JDK 21 and a Node runtime with
+           ;; the `ws` npm package (npm install). Kept separate from :test-runner
+           ;; so the regular matrix doesn't try to load shadow-cljs.
+           :shadow-test {:extra-paths ["src/test-integration" "resources"]
+                         :extra-deps  {thheller/shadow-cljs      {:mvn/version "3.4.11"}
+                                       com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
+                                                                  :sha     "3f288f1f16d167723ad87cc35b1dfee3c1681e10"}}
+                         :main-opts   ["-m" "cognitect.test-runner" "-d" "src/test-integration"]}
+
            ;; build/install/deploy the jar, see build.clj
            :build {:deps       {io.github.clojure/tools.build {:mvn/version "0.10.14"}
                                 slipset/deps-deploy           {:mvn/version "0.2.5"}}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "clj-suitable",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Node dependencies for the shadow-cljs integration test (see src/test-integration).",
+  "devDependencies": {
+    "ws": "^8.18.0"
+  }
+}

--- a/src/test-integration/suitable/shadow_completion_test.clj
+++ b/src/test-integration/suitable/shadow_completion_test.clj
@@ -1,0 +1,64 @@
+(ns suitable.shadow-completion-test
+  "Integration test for the shadow-cljs completion path.
+
+  Unlike `suitable.complete-for-nrepl-test` (which drives a piggieback Node
+  REPL), this exercises `complete-for-shadow-cljs`: it boots a real shadow-cljs
+  server, spins up a Node runtime, and asks for completions through the same
+  code path shadow-cljs uses.
+
+  It is deliberately isolated in `src/test-integration` (with its own
+  `:shadow-test` alias) because shadow-cljs 3.x requires JDK 21 and a Node
+  runtime with the `ws` npm package available - see .github/workflows/ci.yml."
+  (:require
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [shadow.cljs.devtools.api :as shadow]
+   [shadow.cljs.devtools.server :as server]
+   [shadow.cljs.devtools.server.repl-impl :as repl-impl]
+   [shadow.cljs.devtools.server.runtime :as runtime]
+   [suitable.complete-for-nrepl :refer [complete-for-nrepl]]))
+
+(def ^:private build-id :node-repl)
+
+(defn- wait-for-runtime
+  "Block until the node runtime has connected to BUILD-ID, or TIMEOUT-MS passes."
+  [timeout-ms]
+  (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+    (loop []
+      (cond
+        (seq (shadow/repl-runtimes build-id)) true
+        (> (System/currentTimeMillis) deadline) false
+        :else (do (Thread/sleep 200) (recur))))))
+
+(defn- with-shadow-node-runtime [f]
+  (server/start!)
+  (try
+    (repl-impl/node-repl* (runtime/get-instance!) {})
+    (assert (wait-for-runtime 90000)
+            "shadow-cljs node runtime did not connect (is Node installed with the `ws` package?)")
+    (f)
+    (finally
+      (server/stop!))))
+
+(use-fixtures :once with-shadow-node-runtime)
+
+(defn- complete [sym context]
+  (complete-for-nrepl
+   {:shadow.cljs.devtools.server.nrepl-impl/build-id build-id
+    :session (atom {})
+    :symbol sym
+    :ns "cljs.user"
+    :context context}))
+
+(deftest shadow-cljs-dynamic-completion
+  (testing "global completion"
+    (is (= [{:type "function" :candidate "js/Object" :ns "js"}]
+           (complete "js/Ob" nil)))
+    (is (= [{:type "function" :candidate "js/console.log" :ns "js"}]
+           (complete "js/console.lo" nil))))
+
+  (testing "method completion via the `.` interop form (issue #48)"
+    ;; `(.lo js/console)` must complete to `.log`. This works over shadow-cljs's
+    ;; Node runtime, so #48's missing method completions are specific to the
+    ;; browser runtime or a client that doesn't send completion context.
+    (is (= [{:type "function" :candidate ".log" :ns "js/console"}]
+           (complete ".lo" "(__prefix__ js/console)")))))


### PR DESCRIPTION
The shadow-cljs completion path (`complete-for-shadow-cljs`) had zero coverage - the unit tests use a fake eval fn and the existing integration test drives a piggieback Node REPL. That's exactly why #47/#48 slipped through. This adds a real integration test: it boots a shadow-cljs server, connects a Node runtime, and asks for completions through the shadow path.

It also answers #48. Method completion via the `.` interop form (`(.lo js/console)` -> `.log`) works fine over shadow-cljs's Node runtime - I assert it here. So the missing method completions in #48 are specific to the browser runtime or a client that isn't sending completion context, not a bug in suitable's shadow handling.

Getting the runtime to connect took some digging: shadow's node-repl client needs the `ws` npm package, which a deps.edn project doesn't have by default - hence the `package.json` and the `npm install` step.

The test is isolated in `src/test-integration` behind a `:shadow-test` alias with its own CI job, since it needs JDK 21 and a Node runtime. `make shadow-test` runs it locally.

- [x] The commits are consistent with the contribution guidelines
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
