### PR TITLE
Release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+## 0.7.0 (2026-07-12)
+
 - Adapt to piggieback 0.7.0's delegating repl-env so Node.js dynamic completion keeps working.
 - Modernize dependencies (ClojureScript 1.12, compliment 0.8.0, cider-nrepl 0.61.0, shadow-cljs 3.x and more).
 - Drop the ancient Clojure 1.8/1.9/1.10 rows from the CI matrix; test against 1.11, 1.12 and master instead.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ You can now start a figwheel repl via `clj -M:suitable` and use TAB to complete.
 
 First make sure that the [normal leiningen setup](https://figwheel.org/#setting-up-a-build-with-leiningen) works.
 
-Add `[org.rksm/suitable "0.6.2"]` to your dependencies vector.
+Add `[org.rksm/suitable "0.7.0"]` to your dependencies vector.
 
 Then you can start a repl with `lein trampoline run -m suitable.figwheel.main -- -b dev -r`
 
@@ -167,7 +167,7 @@ Also, direct global access is supported such as `js/console.log`. suitable will 
 #### Local install
 
 ```
-PROJECT_VERSION=0.6.2 make install
+PROJECT_VERSION=0.7.0 make install
 ```
 
 #### Releasing to Clojars
@@ -175,7 +175,7 @@ PROJECT_VERSION=0.6.2 make install
 Release to [clojars](https://clojars.org/) by tagging a new release:
 
 ```
-git tag -a v0.6.2 -m "Release 0.6.2"
+git tag -a v0.7.0 -m "Release 0.7.0"
 git push --tags
 ```
 


### PR DESCRIPTION
Cuts 0.7.0: stamps the changelog with the release date and bumps the version references in the README. The actual artifact is published from the `v0.7.0` tag.