### PR TITLE
Actually run the static completion test suite

### DIFF
--- a/src/test/suitable/compliment/sources/cljs_test.clj
+++ b/src/test/suitable/compliment/sources/cljs_test.clj
@@ -1,4 +1,4 @@
-(ns suitable.compliment.sources.t-cljs
+(ns suitable.compliment.sources.cljs-test
   (:require
    [clojure.java.io :as io]
    [clojure.set :as set]
@@ -141,7 +141,7 @@
            (completions "bla")
            (completions "bla" 'suitable.test-ns)))
     (is (= '({:candidate "foo-in-dep" :ns "suitable.test-ns-dep" :type :function})
-           (completions "foo" 'suitable.test-ns))))
+           (completions "foo-in" 'suitable.test-ns))))
 
   (testing "Local fn"
     (is (= '({:candidate "test-public-fn" :ns "suitable.test-ns" :type :function})
@@ -304,7 +304,7 @@
   (testing "Extra metadata: referred var :arglists"
     (binding [*extra-metadata* #{:arglists}]
       (is (= '({:candidate "foo-in-dep" :ns "suitable.test-ns-dep" :arglists ("[foo]") :type :function})
-             (completions "foo" 'suitable.test-ns)))))
+             (completions "foo-in" 'suitable.test-ns)))))
 
   (testing "Extra metadata: referred macro :arglists"
     (binding [*extra-metadata* #{:arglists}]


### PR DESCRIPTION
The static ClojureScript completion tests (formerly `t_cljs.clj`) never ran in CI - the test-runner only matches `*-test` namespaces, and this one was named `t-cljs` from the old `t_` convention. Renaming it to `cljs_test.clj` pulls its 15 tests / 68 assertions into every run.

Running them for the first time surfaced two stale expectations: completing `foo` in the test ns also matches the local `foo` def, not just the referred `foo-in-dep`. I tightened those prefixes to `foo-in` so each test stays focused.

No production code changes - this is purely getting the existing suite to actually execute.