### PR TITLE
Complete local bindings from the surrounding form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Match static completion candidates fuzzily, like compliment does for Clojure (`pr-fn` completes `print-function`, `cs` completes `clojure.string`).
 - Rank static completion candidates with compliment-style priorities (current-ns vars first, then `cljs.core`, then namespaces and classes).
+- Complete local bindings (`let`/`loop`/`fn`/`for`/`doseq`/... including destructuring) from the surrounding form, like compliment does for Clojure.
 
 ## 0.7.0 (2026-07-12)
 

--- a/src/main/suitable/compliment/sources/cljs.clj
+++ b/src/main/suitable/compliment/sources/cljs.clj
@@ -2,7 +2,9 @@
   "Standalone auto-complete library based on cljs analyzer state"
   (:refer-clojure :exclude [meta])
   (:require [clojure.set :as set]
+            [compliment.context :as ctx]
             [compliment.sources :refer [defsource]]
+            [compliment.sources.local-bindings :as local-bindings]
             [compliment.utils :as utils :refer [*extra-metadata*]]
             [suitable.compliment.sources.cljs.analysis :as ana])
   (:import java.io.StringWriter))
@@ -314,18 +316,29 @@
        (filter #(candidate-match? % prefix))
        (map #(with-priority context-ns %))))
 
+(defn- local-candidates
+  "Local bindings (from let/loop/fn/for/doseq/... forms, including
+  destructuring) visible at the completion point. This reuses compliment's own
+  extractor, which is purely structural and so works for ClojureScript too.
+  `context` is the parsed context compliment hands to a source; we also accept a
+  raw string for callers that don't pre-parse it."
+  [prefix ns context]
+  (let [parsed (if (string? context) (ctx/cache-context context) context)]
+    (local-bindings/candidates prefix ns parsed)))
+
 (defn candidates
   "Returns a sequence of candidate data for completions matching the given
   prefix string and options.
 
   It requires the compliment.sources.cljs/*compiler-env* var to be dynamically
   bound to the ClojureScript compiler env."
-  [prefix ns _context]
+  [prefix ns context]
   (let [context-ns (try
                      (ns-name ns)
                      (catch Exception _
                        nil))]
-    (candidates* prefix context-ns)))
+    (concat (candidates* prefix context-ns)
+            (local-candidates prefix ns context))))
 
 (defn generate-docstring
   "Generates a docstring from a given var metadata.

--- a/src/test/suitable/compliment/sources/cljs_test.clj
+++ b/src/test/suitable/compliment/sources/cljs_test.clj
@@ -24,6 +24,13 @@
   [prefix & [ns]]
   (map #(dissoc % :priority) (completions* prefix ns)))
 
+(defn completions-in-context
+  "Candidates given a surrounding context form (a string with the cursor's
+  symbol replaced by `__prefix__`), with :priority stripped."
+  [prefix ns context]
+  (map #(dissoc % :priority)
+       (cljs-sources/candidates prefix (some-> ns find-ns) context)))
+
 (defn set=
   [coll1 coll2 & colls]
   (apply = (set coll1) (set coll2) (map set colls)))
@@ -43,7 +50,7 @@
       (is (every? (comp string? :candidate) all-candidates)))
 
     (testing "All candidates that should have an :ns, do"
-      (let [filter-fn #(not (#{:import :keyword :namespace :class} (:type %)))
+      (let [filter-fn #(not (#{:import :keyword :namespace :class :local} (:type %)))
             filtered-candidates (filter filter-fn all-candidates)]
         (is (every? :ns filtered-candidates))))
 
@@ -51,6 +58,7 @@
       (let [valid-types #{:function
                           :class
                           :keyword
+                          :local
                           :macro
                           :namespace
                           :protocol
@@ -323,6 +331,23 @@
     (testing "keywords and special forms carry no priority (sink to the bottom)"
       (is (nil? (:priority (first (completions* ":on" 'suitable.test-ns)))))
       (is (nil? (:priority (first (completions* "thr"))))))))
+
+(deftest local-bindings-completion
+  (testing "let bindings are completed from the surrounding context"
+    (is (some #{{:candidate "foobar" :type :local}}
+              (completions-in-context "foo" 'suitable.test-ns "(let [foobar 1] __prefix__)"))))
+
+  (testing "fn arguments"
+    (is (some #{{:candidate "bravo" :type :local}}
+              (completions-in-context "br" 'suitable.test-ns "(fn [alpha bravo] __prefix__)"))))
+
+  (testing "map destructuring"
+    (is (some #{{:candidate "alpha" :type :local}}
+              (completions-in-context "al" 'suitable.test-ns "(let [{:keys [alpha beta]} m] __prefix__)"))))
+
+  (testing "no locals without a binding context"
+    (is (empty? (->> (completions-in-context "foo" 'suitable.test-ns "(__prefix__)")
+                     (filter #(= :local (:type %))))))))
 
 (deftest extra-metadata
   (testing "Extra metadata: namespace :doc"


### PR DESCRIPTION
The static source ignored the completion context, so it could never complete a local `let`/`fn`/`for` binding - one of the more basic things compliment does for Clojure. It now feeds the context to compliment's own `local-bindings` extractor.

The nice part: that extractor is purely structural (it recognizes binding forms by name and walks the destructuring), so it works for ClojureScript unmodified. The only Clojure-specific bits are optional `:tag` inference, which degrades to nil for cljs without throwing. So this is reuse rather than a reimplementation.

Locals come back shaped exactly like compliment's (`:type :local`, no `:priority`). The source also learned to accept a raw context string and parse it via `compliment.context`, for callers that don't pre-parse.

Covered by new tests (let bindings, fn args, destructuring, and the no-context case), green under CLJS 1.11 and 1.12.

- [x] The commits are consistent with the contribution guidelines
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
