### PR TITLE
Make static completion context-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Match static completion candidates fuzzily, like compliment does for Clojure (`pr-fn` completes `print-function`, `cs` completes `clojure.string`).
 - Rank static completion candidates with compliment-style priorities (current-ns vars first, then `cljs.core`, then namespaces and classes).
 - Complete local bindings (`let`/`loop`/`fn`/`for`/`doseq`/... including destructuring) from the surrounding form, like compliment does for Clojure.
+- Complete referred vars inside a `(:require [some.ns :refer [...]])` clause, scoped to that namespace.
+- Only offer special forms at the head of a list, matching compliment.
 
 ## 0.7.0 (2026-07-12)
 

--- a/src/main/suitable/compliment/sources/cljs.clj
+++ b/src/main/suitable/compliment/sources/cljs.clj
@@ -316,15 +316,35 @@
        (filter #(candidate-match? % prefix))
        (map #(with-priority context-ns %))))
 
-(defn- local-candidates
-  "Local bindings (from let/loop/fn/for/doseq/... forms, including
-  destructuring) visible at the completion point. This reuses compliment's own
-  extractor, which is purely structural and so works for ClojureScript too.
-  `context` is the parsed context compliment hands to a source; we also accept a
-  raw string for callers that don't pre-parse it."
-  [prefix ns context]
-  (let [parsed (if (string? context) (ctx/cache-context context) context)]
-    (local-bindings/candidates prefix ns parsed)))
+(defn- require-refer-ns
+  "If the parsed `context` places the cursor inside a
+  `(ns ... (:require [some.ns :refer [__prefix__]]))` clause (or the `:use`/
+  `:only` equivalent), returns the symbol of that namespace, otherwise nil.
+  Ported from compliment's vars source."
+  [context]
+  (let [[refer-list libspec require-clause ns-form] context]
+    (when (and (sequential? (:form refer-list))
+               (= (first (:form ns-form)) 'ns)
+               (or (and (= (first (:form require-clause)) :require)
+                        (= (second (:form libspec)) :refer))
+                   (and (= (first (:form require-clause)) :use)
+                        (= (second (:form libspec)) :only))))
+      (first (:form libspec)))))
+
+(defn- refer-candidates
+  "Candidates for a `:refer`/`:only` position: the public vars of `refer-ns`."
+  [context-ns refer-ns prefix]
+  (->> (ns-public-var-candidates *compiler-env* refer-ns *extra-metadata*)
+       (filter #(candidate-match? % prefix))
+       (map #(with-priority context-ns %))))
+
+(defn- first-item-in-list?
+  "Special forms are only relevant when the prefix is the first element of a list
+  (or when there's no context to tell). Ported from compliment."
+  [context]
+  (if-let [{:keys [form idx]} (first context)]
+    (and (list? form) (= idx 0))
+    true))
 
 (defn candidates
   "Returns a sequence of candidate data for completions matching the given
@@ -336,9 +356,19 @@
   (let [context-ns (try
                      (ns-name ns)
                      (catch Exception _
-                       nil))]
-    (concat (candidates* prefix context-ns)
-            (local-candidates prefix ns context))))
+                       nil))
+        ;; `context` is already parsed when we're called via compliment.core; we
+        ;; also accept a raw string for callers that don't pre-parse it.
+        parsed (if (string? context) (ctx/cache-context context) context)]
+    (if-let [refer-ns (require-refer-ns parsed)]
+      ;; inside a (:require [refer-ns :refer [__prefix__]]) clause -> that ns' publics
+      (refer-candidates context-ns refer-ns prefix)
+      (cond->> (concat (candidates* prefix context-ns)
+                       ;; compliment's local-bindings extractor is purely
+                       ;; structural, so it works unchanged for ClojureScript.
+                       (local-bindings/candidates prefix ns parsed))
+        (not (first-item-in-list? parsed))
+        (remove #(= :special-form (:type %)))))))
 
 (defn generate-docstring
   "Generates a docstring from a given var metadata.

--- a/src/test/suitable/compliment/sources/cljs_test.clj
+++ b/src/test/suitable/compliment/sources/cljs_test.clj
@@ -69,6 +69,19 @@
                           :var}]
         (is (every? (comp valid-types :type) all-candidates))))))
 
+(deftest special-form-context
+  (testing "special forms are offered at the head of a list"
+    (is (some #{{:candidate "throw" :ns "cljs.core" :type :special-form}}
+              (completions-in-context "thr" nil "(__prefix__ x)"))))
+
+  (testing "but not in argument position"
+    (is (not-any? #(= :special-form (:type %))
+                  (completions-in-context "thr" nil "(foo __prefix__)"))))
+
+  (testing "and are offered when there is no context (can't tell position)"
+    (is (some #{{:candidate "throw" :ns "cljs.core" :type :special-form}}
+              (completions "thr")))))
+
 (deftest special-form-completions
   (testing "Special form"
     (is (= '({:candidate "throw" :ns "cljs.core" :type :special-form})
@@ -348,6 +361,20 @@
   (testing "no locals without a binding context"
     (is (empty? (->> (completions-in-context "foo" 'suitable.test-ns "(__prefix__)")
                      (filter #(= :local (:type %))))))))
+
+(deftest require-refer-completion
+  (let [refer-ctx "(ns foo (:require [clojure.string :refer [__prefix__]]))"]
+    (testing "inside a :refer vector, completes the referred ns' public vars"
+      (is (some #{{:candidate "blank?" :ns "clojure.string" :type :function}}
+                (completions-in-context "bl" 'suitable.test-ns refer-ctx))))
+
+    (testing "and scopes to that ns - a cljs.core var must not leak in"
+      (is (not-any? #(= "bit-shift-left" (:candidate %))
+                    (completions-in-context "bi" 'suitable.test-ns refer-ctx))))
+
+    (testing "outside a :refer clause, normal completion still applies"
+      (is (some #(= "bit-shift-left" (:candidate %))
+                (completions-in-context "bit" 'suitable.test-ns "(__prefix__)"))))))
 
 (deftest extra-metadata
   (testing "Extra metadata: namespace :doc"


### PR DESCRIPTION
The static source discarded the completion context entirely, so it couldn't tell where in the form the cursor sat. It now parses the context once and uses it for two things compliment also does:

- Inside a `(:require [some.ns :refer [__prefix__]])` clause, it completes that namespace's public vars (scoped) instead of the usual grab-bag - so `[clojure.string :refer [bl|]]` offers `blank?`, not every `bl*` in scope.
- Special forms are only offered at the head of a list, not in argument position.

The refer detection is ported from compliment's vars source but wired to the cljs analyzer for the actual var lookup. I left import-list completion out on purpose - unlike the JVM, cljs has no ready catalog of importable Closure classes to offer, so there's nothing clean to complete against there.

New tests for both, green under CLJS 1.11 and 1.12.

- [x] The commits are consistent with the contribution guidelines
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
