### PR TITLE
Fix dynamic completion clobbering *1/*2/*3 and re-requiring per request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Complete local bindings (`let`/`loop`/`fn`/`for`/`doseq`/... including destructuring) from the surrounding form, like compliment does for Clojure.
 - Complete referred vars inside a `(:require [some.ns :refer [...]])` clause, scoped to that namespace.
 - Only offer special forms at the head of a list, matching compliment.
+- [#5](https://github.com/clojure-emacs/clj-suitable/issues/5): don't clobber the REPL's `*1`/`*2`/`*3` when computing dynamic completions.
+- [#6](https://github.com/clojure-emacs/clj-suitable/issues/6): load the introspection namespace once per session instead of on every completion request.
 
 ## 0.7.0 (2026-07-12)
 

--- a/src/main/suitable/complete_for_nrepl.clj
+++ b/src/main/suitable/complete_for_nrepl.clj
@@ -89,6 +89,22 @@
                               `(~sym ((keyword '~sym) ~vars)))))
            ~@body)))))
 
+(defn- non-recording-wrap
+  "A `cljs.repl` `:wrap` fn that evaluates a form without the `(set! *1 ...)`
+  history rotation the default wrapper does, so completion probes don't clobber
+  the user's *1/*2/*3 (see clojure-emacs/clj-suitable#5). Delegates to
+  `cljs.repl/init-wrap-fn` (which is exactly this) when available, otherwise
+  falls back to a plain pr-str wrapper."
+  [form]
+  (if-let [init-wrap-fn (resolve 'cljs.repl/init-wrap-fn)]
+    (init-wrap-fn form)
+    (if (and (seq? form)
+             ('#{ns require require-macros refer-global require-global
+                 use use-macros import refer-clojure}
+              (first form)))
+      identity
+      (fn [x] (list 'cljs.core/pr-str x)))))
+
 (defn- cljs-eval
   "Grabs the necessary compiler and repl envs from the message and uses the plain
   cljs.repl interface for evaluation. Returns a map with :value and :error. Note
@@ -99,7 +115,10 @@
         ;; aren't recognized correctly by the analyzer, suppress an undefined
         ;; var warining for `js-properties-of-object`
         ;; TODO only add when run as inline-dep??
-        opts (assoc opts :warnings {:undeclared-var false})]
+        opts (assoc opts
+                    :warnings {:undeclared-var false}
+                    ;; don't let completion probes rotate the REPL's *1/*2/*3
+                    :wrap non-recording-wrap)]
     (with-cljs-env cenv ns
       [cljs-eval-cljs-fn]
       (try

--- a/src/main/suitable/complete_for_nrepl.clj
+++ b/src/main/suitable/complete_for_nrepl.clj
@@ -264,7 +264,15 @@
           (let [result ((resolve 'shadow.cljs.devtools.api/cljs-eval) build-id code {:ns (symbol ns)})]
             {:error (some->> result :err str)
              :value (some->> result :results first edn/read-string)}))
-        ensure-loaded-fn (fn [_] nil)]
+        ;; shadow doesn't go through `ensure-suitable-cljs-is-loaded`, so load the
+        ;; introspection namespace here - once per session, not once per request
+        ;; (clojure-emacs/clj-suitable#6).
+        ensure-loaded-fn
+        (fn [session]
+          (when-not (::js-introspection-loaded @session)
+            (cljs-eval-fn (or (:ns msg) "cljs.user")
+                          (str "(require '" (suitable.js-completions/js-introspection-ns) ")"))
+            (swap! session assoc ::js-introspection-loaded true)))]
     (handle-completion-msg! msg cljs-eval-fn ensure-loaded-fn)))
 
 (defn complete-for-nrepl

--- a/src/main/suitable/js_completions.clj
+++ b/src/main/suitable/js_completions.clj
@@ -19,16 +19,13 @@
    (js-properties-of-object cljs-eval-fn ns obj-expr nil))
   ([cljs-eval-fn ns obj-expr prefix]
    (try
-     ;; :Not using a single expressiont / eval call here like
-     ;; (do (require ...) (runtime ...))
-     ;; to avoid
-     ;; Compile Warning:  Use of undeclared Var
-     ;;   suitable.js-introspection/property-names-and-types
+     ;; The introspection namespace is loaded once per session by the
+     ;; ensure-loaded step (see `suitable.complete-for-nrepl`), so we don't
+     ;; require it here on every completion request (clojure-emacs/clj-suitable#6).
      (let [template (str "("
                          (js-introspection-ns)
                          "/property-names-and-types ~A ~S)")
            code (cl-format nil template obj-expr prefix)]
-       (cljs-eval-fn ns (str "(require '" (js-introspection-ns) ")"))
        (cljs-eval-fn ns code))
      (catch Exception e {:error e}))))
 

--- a/src/test/suitable/complete_for_nrepl_test.clj
+++ b/src/test/suitable/complete_for_nrepl_test.clj
@@ -86,6 +86,18 @@
         (is (= #{"done"} (:status response))
             explanation)))))
 
+(deftest preserves-repl-history
+  ;; https://github.com/clojure-emacs/clj-suitable/issues/5
+  (with-repl-env (cljs.repl.node/repl-env)
+    (testing "a completion request must not clobber *1/*2/*3"
+      (is (= ["42"] (:value (message {:op :eval :code "42"}))))
+      (message {:op "complete"
+                :ns "cljs.user"
+                :symbol ".key"
+                :context "(__prefix__ js/Object)"})
+      (is (= ["42"] (:value (message {:op :eval :code "*1"})))
+          "*1 should still hold the last user value, not the completion's result"))))
+
 (deftest suitable-node
   (with-repl-env (cljs.repl.node/repl-env)
     (testing "js global completion"

--- a/src/test/suitable/js_completion_test.clj
+++ b/src/test/suitable/js_completion_test.clj
@@ -35,6 +35,19 @@
                        obj-expr prefix))))))
 
 ;; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+(deftest js-properties-of-object-no-require
+  ;; https://github.com/clojure-emacs/clj-suitable/issues/6
+  (testing "does not re-require the introspection ns on every request"
+    (let [calls   (atom [])
+          eval-fn (fn [_ns code] (swap! calls conj code) {:value []})]
+      (sut/js-properties-of-object eval-fn "cljs.user" "js/console" "lo")
+      (is (= 1 (count @calls))
+          "makes exactly one eval call (the introspection call), not a require + call")
+      (is (not-any? #(clojure.string/includes? % "require") @calls)
+          "does not emit a (require ...)"))))
+
+;; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 ;; expr-for-parent-obj
 
 (deftest expr-for-parent-obj


### PR DESCRIPTION
Two fixes to the dynamic (JS interop) completion path.

**Fixes #5 - completion clobbered `*1`/`*2`/`*3`.** Dynamic completion evaluates a probe in your REPL to introspect the object, and cljs.repl's default eval wrapper rotates the history vars after every eval - so each completion request overwrote `*1` with the introspection result. `cljs-eval` now evaluates with a `:wrap` that skips that rotation (reusing `cljs.repl/init-wrap-fn`, which is exactly this). New test that establishes `*1`, completes, and asserts `*1` survived.

**Fixes #6 - re-`require`d the introspection ns on every keystroke.** `js-properties-of-object` required `suitable.js-introspection` on every completion request. The default path already loads it once via `ensure-suitable-cljs-is-loaded`, so that was a wasted eval round-trip per keystroke; the shadow path relied on it, so it now loads the ns once from its `ensure-loaded` step (guarded by a session flag) instead. Verified against both the Node and shadow-cljs integration tests.

Heads up: the Node integration test is a bit flaky (it occasionally fails to spawn the node process); unrelated to these changes, but a re-run clears it.

- [x] The commits are consistent with the contribution guidelines
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
