### PR TITLE
Surface failed introspection-namespace loads in the shadow-cljs path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Only offer special forms at the head of a list, matching compliment.
 - [#5](https://github.com/clojure-emacs/clj-suitable/issues/5): don't clobber the REPL's `*1`/`*2`/`*3` when computing dynamic completions.
 - [#6](https://github.com/clojure-emacs/clj-suitable/issues/6): load the introspection namespace once per session instead of on every completion request.
+- [#47](https://github.com/clojure-emacs/clj-suitable/issues/47), [#48](https://github.com/clojure-emacs/clj-suitable/issues/48): surface a failed introspection-namespace load in the shadow-cljs path instead of silently caching it, so browser-runtime failures are diagnosable and retried.
 
 ## 0.7.0 (2026-07-12)
 

--- a/src/main/suitable/complete_for_nrepl.clj
+++ b/src/main/suitable/complete_for_nrepl.clj
@@ -254,6 +254,23 @@
 (defn- shadow-cljs? [msg]
   (:shadow.cljs.devtools.server.nrepl-impl/build-id msg))
 
+(defn require-introspection-ns!
+  "Loads the introspection namespace into the shadow-cljs runtime, once per
+  session (clojure-emacs/clj-suitable#6). Shadow doesn't go through
+  `ensure-suitable-cljs-is-loaded`, so it's loaded here with a plain `require`.
+
+  The session is marked loaded only when the require actually succeeds. A failed
+  load - e.g. the mranderson-inlined introspection ns not being available in a
+  browser runtime (clojure-emacs/clj-suitable#47/#48) - is surfaced and left
+  uncached, so it's retried and diagnosable rather than silently swallowed."
+  [cljs-eval-fn session ns]
+  (when-not (::js-introspection-loaded @session)
+    (let [{:keys [error]} (cljs-eval-fn ns (str "(require '" (suitable.js-completions/js-introspection-ns) ")"))]
+      (if (seq error)
+        (println (format "suitable error: could not load the introspection namespace (enable %s/debug for more details): %s"
+                         this-ns error))
+        (swap! session assoc ::js-introspection-loaded true)))))
+
 (defn- complete-for-shadow-cljs
   "Shadow-cljs handles evals quite differently from normal cljs so we need some
   special handling here."
@@ -264,15 +281,9 @@
           (let [result ((resolve 'shadow.cljs.devtools.api/cljs-eval) build-id code {:ns (symbol ns)})]
             {:error (some->> result :err str)
              :value (some->> result :results first edn/read-string)}))
-        ;; shadow doesn't go through `ensure-suitable-cljs-is-loaded`, so load the
-        ;; introspection namespace here - once per session, not once per request
-        ;; (clojure-emacs/clj-suitable#6).
         ensure-loaded-fn
         (fn [session]
-          (when-not (::js-introspection-loaded @session)
-            (cljs-eval-fn (or (:ns msg) "cljs.user")
-                          (str "(require '" (suitable.js-completions/js-introspection-ns) ")"))
-            (swap! session assoc ::js-introspection-loaded true)))]
+          (require-introspection-ns! cljs-eval-fn session (or (:ns msg) "cljs.user")))]
     (handle-completion-msg! msg cljs-eval-fn ensure-loaded-fn)))
 
 (defn complete-for-nrepl

--- a/src/test/suitable/complete_for_nrepl_test.clj
+++ b/src/test/suitable/complete_for_nrepl_test.clj
@@ -145,6 +145,30 @@
         "(__prefix__ (js/Set. (js/Array. 1 2 3)))"
         [{:candidate ".-size", :ns "(js/Set. (js/Array. 1 2 3))", :type "var"}]))))
 
+(deftest require-introspection-ns
+  ;; https://github.com/clojure-emacs/clj-suitable/issues/47
+  (testing "loads once and marks the session loaded on success"
+    (let [calls   (atom [])
+          eval-fn (fn [ns code] (swap! calls conj [ns code]) {:value nil :error nil})
+          session (atom {})]
+      (sut/require-introspection-ns! eval-fn session "cljs.user")
+      (is (= 1 (count @calls)) "evals the require once")
+      (is (true? (::sut/js-introspection-loaded @session)))
+      (sut/require-introspection-ns! eval-fn session "cljs.user")
+      (is (= 1 (count @calls)) "does not re-require once loaded")))
+
+  (testing "a failed load is surfaced and left uncached, so it is retried"
+    (let [calls   (atom [])
+          eval-fn (fn [ns code] (swap! calls conj [ns code]) {:value nil :error "cider is not defined"})
+          session (atom {})
+          out     (with-out-str (sut/require-introspection-ns! eval-fn session "cljs.user"))]
+      (is (not (contains? @session ::sut/js-introspection-loaded))
+          "must not mark loaded when the require errored")
+      (is (string/includes? out "could not load the introspection namespace")
+          "surfaces the failure instead of swallowing it")
+      (with-out-str (sut/require-introspection-ns! eval-fn session "cljs.user"))
+      (is (= 2 (count @calls)) "retries the load after a failure"))))
+
 (deftest node-env?
   (is (false? (sut/node-env? nil)))
   (is (false? (sut/node-env? 42)))


### PR DESCRIPTION
The shadow-cljs completion path loaded the introspection namespace once per session (#6), but it marked the session loaded even when the `(require ...)` failed - caching the failure for the whole session and swallowing the error. When a browser runtime can't load the mranderson-inlined introspection ns (#47/#48), the user just gets no completions with no signal at all.

This extracts the loader into `require-introspection-ns!`, marks the session loaded only when the require succeeds, and prints the error otherwise - so the failure is diagnosable and retried instead of silently cached. Adds a unit test for both the success (loads once) and failure (uncached, surfaced, retried) paths.

This is hardening around #47/#48, not a full fix - reproducing and fixing the inlined-ns browser load still needs an mranderson-inlined build. Refs #47, #48.